### PR TITLE
feat(lib): support sampled tracing with a sample ratio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ minitrace = { version = "0.5.1", features = ["enable"] }
 minitrace-opentelemetry = "0.5.1"
 opentelemetry = { version = "0.19", features = ["trace"] }
 opentelemetry-otlp = { version = "0.12", features = ["trace", "grpc-sys"] }
+rand = "0.8.5"
+once_cell = "1.13.1"
 
 [build-dependencies]
 cxx-build = "1.0.106"

--- a/include/minitrace_c.h
+++ b/include/minitrace_c.h
@@ -68,6 +68,12 @@ mtr_span_ctx mtr_create_span_ctx_loc(void);
  */
 mtr_span mtr_create_root_span(const char *name, mtr_span_ctx parent);
 
+/* Same as mtr_create_root_span, but return a non-empty span only with probability `prob`. */
+mtr_span mtr_create_root_span_with_prob(const char *name, mtr_span_ctx parent, float prob);
+
+/* Same as mtr_create_root_span_with_prob, but read `prob` from environment variable MINITRACE_SAMPLE_RATIO. */
+mtr_span mtr_create_root_span_with_preset_prob(const char *name, mtr_span_ctx parent);
+
 /* Create a new child span associated with the specified parent span. */
 mtr_span mtr_create_child_span_enter(const char *name, mtr_span const *parent);
 

--- a/src/minitrace_c.cpp
+++ b/src/minitrace_c.cpp
@@ -86,6 +86,22 @@ mtr_span mtr_create_root_span(const char *name, mtr_span_ctx parent) {
   return std::move(_ms.c);
 }
 
+mtr_span mtr_create_root_span_with_prob(const char *name, mtr_span_ctx parent, float prob) {
+  union _mtr_span _ms = {
+      .f = minitrace_glue::mtr_create_root_span_with_prob(
+          name, *(ffi::mtr_span_ctx *)(&parent), prob),
+  };
+  return std::move(_ms.c);
+}
+
+mtr_span mtr_create_root_span_with_preset_prob(const char *name, mtr_span_ctx parent) {
+  union _mtr_span _ms = {
+      .f = minitrace_glue::mtr_create_root_span_with_preset_prob(
+          name, *(ffi::mtr_span_ctx *)(&parent)),
+  };
+  return std::move(_ms.c);
+}
+
 mtr_span mtr_create_child_span_enter(const char *name, mtr_span const *parent) {
   union _mtr_span _p = {
       .c = *parent,


### PR DESCRIPTION
add a variant of mtr_create_root_span, mtr_create_root_span_with_preset_prob, that returns a noop span with a given probability